### PR TITLE
refactor: move rate limiter location

### DIFF
--- a/src/qianfan/resources/requestor/base.py
+++ b/src/qianfan/resources/requestor/base.py
@@ -88,7 +88,8 @@ class BaseAPIRequestor(object):
         """
         simple sync request
         """
-        response = self._client.request(request)
+        with self._rate_limiter:
+            response = self._client.request(request)
         _check_if_status_code_is_200(response)
         try:
             body = response.json()
@@ -106,7 +107,8 @@ class BaseAPIRequestor(object):
         """
         stream sync request
         """
-        responses = self._client.request_stream(request)
+        with self._rate_limiter:
+            responses = self._client.request_stream(request)
         for body, resp in responses:
             _check_if_status_code_is_200(resp)
             body_str = body.decode("utf-8")
@@ -137,7 +139,8 @@ class BaseAPIRequestor(object):
         """
         async request
         """
-        response, session = await self._client.arequest(request)
+        async with self._rate_limiter:
+            response, session = await self._client.arequest(request)
         async with session:
             async with response:
                 _async_check_if_status_code_is_200(response)
@@ -158,7 +161,8 @@ class BaseAPIRequestor(object):
         """
         async stream request
         """
-        responses = self._client.arequest_stream(request)
+        async with self._rate_limiter:
+            responses = self._client.arequest_stream(request)
         async for body, resp in responses:
             _async_check_if_status_code_is_200(resp)
             body_str = body.decode("utf-8")

--- a/src/qianfan/resources/requestor/openapi_requestor.py
+++ b/src/qianfan/resources/requestor/openapi_requestor.py
@@ -62,16 +62,15 @@ class QfAPIRequestor(BaseAPIRequestor):
         def retry_wrapper(*args: Any, **kwargs: Any) -> _T:
             nonlocal token_refreshed
             # if token is refreshed, token expired exception will not be dealt with
-            with self._rate_limiter:
-                if not token_refreshed:
-                    try:
-                        return func(*args)
-                    except errors.AccessTokenExpiredError:
-                        # refresh token and set token_refreshed flag
-                        self._auth.refresh_access_token()
-                        token_refreshed = True
-                        # then fallthrough and try again
-                return func(*args, **kwargs)
+            if not token_refreshed:
+                try:
+                    return func(*args)
+                except errors.AccessTokenExpiredError:
+                    # refresh token and set token_refreshed flag
+                    self._auth.refresh_access_token()
+                    token_refreshed = True
+                    # then fallthrough and try again
+            return func(*args, **kwargs)
 
         return retry_wrapper
 
@@ -86,16 +85,15 @@ class QfAPIRequestor(BaseAPIRequestor):
         async def retry_wrapper(*args: Any, **kwargs: Any) -> _T:
             nonlocal token_refreshed
             # if token is refreshed, token expired exception will not be dealt with
-            async with self._rate_limiter:
-                if not token_refreshed:
-                    try:
-                        return await func(*args)
-                    except errors.AccessTokenExpiredError:
-                        # refresh token and set token_refreshed flag
-                        await self._auth.arefresh_access_token()
-                        token_refreshed = True
-                        # then fallthrough and try again
-                return await func(*args, **kwargs)
+            if not token_refreshed:
+                try:
+                    return await func(*args)
+                except errors.AccessTokenExpiredError:
+                    # refresh token and set token_refreshed flag
+                    await self._auth.arefresh_access_token()
+                    token_refreshed = True
+                    # then fallthrough and try again
+            return await func(*args, **kwargs)
 
         return retry_wrapper
 


### PR DESCRIPTION
  - **Description:** move rate limiter to `BaseAPIRequestor`
  - **Issue:** #72 
  - **Dependencies:** None

