### PR TITLE
feat: support two different dataset format

### DIFF
--- a/src/qianfan/dataset/__init__.py
+++ b/src/qianfan/dataset/__init__.py
@@ -19,6 +19,14 @@ Library aimed to helping developer to interactive with Dataset
 from qianfan.dataset.data_source import DataSource, FileDataSource, QianfanDataSource
 from qianfan.dataset.dataset import Dataset
 from qianfan.dataset.table import Table
+from qianfan.resources.console.consts import (
+    DataExportDestinationType,
+    DataProjectType,
+    DataSetType,
+    DataSourceType,
+    DataStorageType,
+    DataTemplateType,
+)
 
 __all__ = [
     "DataSource",
@@ -26,4 +34,10 @@ __all__ = [
     "QianfanDataSource",
     "Dataset",
     "Table",
+    "DataTemplateType",
+    "DataSetType",
+    "DataSourceType",
+    "DataStorageType",
+    "DataProjectType",
+    "DataExportDestinationType",
 ]

--- a/src/qianfan/dataset/data_source.py
+++ b/src/qianfan/dataset/data_source.py
@@ -182,6 +182,11 @@ class FileDataSource(DataSource, BaseModel):
         Returns:
             str: A string containing the data read from the file.
         """
+        # 检查文件是否存在且非目录
+        if not os.path.exists(self.path):
+            raise ValueError("file path not found")
+        if os.path.isdir(self.path):
+            raise ValueError("cannot read from folder")
         with open(self.path, mode="r") as file:
             return file.read()
 
@@ -223,12 +228,6 @@ class FileDataSource(DataSource, BaseModel):
             return self
 
         try:
-            # 检查文件是否存在且非目录
-            if not os.path.exists(self.path):
-                raise ValueError("file path not found")
-            if os.path.isdir(self.path):
-                raise ValueError("cannot read from folder")
-
             index = self.path.rfind(".")
             # 查询不到的情况下默认使用纯文本格式
             if index == -1:

--- a/src/qianfan/dataset/dataset.py
+++ b/src/qianfan/dataset/dataset.py
@@ -627,7 +627,7 @@ class Dataset(Table):
         self, elem: Any, add_new_group: bool = False, is_grouped: bool = True
     ) -> Self:
         """
-        append an element to dataset
+        append element(s) to dataset
 
         Args:
             elem (Union[List[Dict], Tuple[Dict], Dict]): Elements added to dataset
@@ -647,6 +647,37 @@ class Dataset(Table):
             Self: Dataset itself
         """
         return super().append(elem, add_new_group, is_grouped)
+
+    @_online_except_decorator
+    def insert(
+        self,
+        elem: Any,
+        index: Any,
+        add_new_group: bool = False,
+        is_grouped: bool = True,
+    ) -> Self:
+        """
+        insert element(s) to dataset
+
+        Args:
+            elem (Union[List[Dict], Tuple[Dict], Dict]): Elements added to dataset
+            index (int): where to insert element(s)
+            add_new_group (bool):
+                Whether elem has a new group id.
+                Only used when dataset is grouped.
+            is_grouped (bool):
+                Are element in elem in same group.
+                Only used when dataset is grouped and elem is Sequence
+                and add_new_group was set True.
+                Default to True, all elements
+                will be in same group.
+                If it's True, each element will have
+                sequential incremental group id from last
+                available group id.
+        Returns:
+            Self: Dataset itself
+        """
+        return super().insert(elem, index, add_new_group, is_grouped)
 
     def list(
         self,
@@ -794,6 +825,20 @@ class Dataset(Table):
         Args:
             elem (Dict[str, List]): dict containing element added to dataset
                 must has column name "name" and column data list "data"
+        Returns:
+            Self: Dataset itself
+        """
+        return super().col_append(elem)
+
+    @_online_except_decorator
+    def col_insert(self, elem: Any, index: Any) -> Self:
+        """
+        append a row to dataset
+
+        Args:
+            elem (Dict[str, List]): dict containing element added to dataset
+                must has column name "name" and column data list "data"
+            index (int): where to insert new column
         Returns:
             Self: Dataset itself
         """

--- a/src/qianfan/dataset/dataset.py
+++ b/src/qianfan/dataset/dataset.py
@@ -219,6 +219,7 @@ class Dataset(Table):
         data_file: Optional[str] = None,
         qianfan_dataset_id: Optional[int] = None,
         qianfan_dataset_create_args: Optional[Dict[str, Any]] = None,
+        bos_load_args: Optional[Dict[str, Any]] = None,
         huggingface_name: Optional[str] = None,
         **kwargs: Any,
     ) -> Optional[DataSource]:
@@ -243,6 +244,13 @@ class Dataset(Table):
                 f" {qianfan_dataset_create_args}, with args: {kwargs}"
             )
             return QianfanDataSource.create_bare_dataset(**qianfan_dataset_create_args)
+
+        if bos_load_args:
+            log_info(
+                "construct a new qianfan data source from bos loading:"
+                f" {bos_load_args}, with args: {kwargs}"
+            )
+            return QianfanDataSource.create_from_bos_file(**bos_load_args)
         if huggingface_name:
             error = ValueError("huggingface not supported yet")
             log_error(str(error))
@@ -257,6 +265,7 @@ class Dataset(Table):
         source: Optional[DataSource] = None,
         data_file: Optional[str] = None,
         qianfan_dataset_id: Optional[int] = None,
+        bos_load_args: Optional[Dict[str, Any]] = None,
         huggingface_name: Optional[str] = None,
         schema: Optional[Schema] = None,
         organize_data_as_qianfan: bool = False,
@@ -276,6 +285,9 @@ class Dataset(Table):
                 dataset local file path, default to None
             qianfan_dataset_id (Optional[int]):
                 qianfan dataset ID, default to None
+            bos_load_args: (Optional[Dict[str, Any]]):
+                create a dataset and import initial dataset content
+                from args
             huggingface_name (Optional[str]):
                 Hugging Face dataset name, not available now
             schema (Optional[Schema]):
@@ -297,6 +309,7 @@ class Dataset(Table):
             source = cls._from_args_to_source(
                 data_file=data_file,
                 qianfan_dataset_id=qianfan_dataset_id,
+                bos_load_args=bos_load_args,
                 huggingface_name=huggingface_name,
                 **kwargs,
             )
@@ -322,7 +335,6 @@ class Dataset(Table):
         data_file: Optional[str] = None,
         qianfan_dataset_id: Optional[int] = None,
         qianfan_dataset_create_args: Optional[Dict[str, Any]] = None,
-        huggingface_name: Optional[str] = None,
         schema: Optional[Schema] = None,
         **kwargs: Any,
     ) -> bool:
@@ -343,8 +355,6 @@ class Dataset(Table):
             qianfan_dataset_create_args: (Optional[Dict[str: Any]]):
                 create arguments for creating a bare dataset on qianfan,
                 default to None
-            huggingface_name (Optional[str]):
-                Hugging Face dataset name, not available now
             schema: (Optional[Schema]):
                 schema used to validate before exporting data, default to None
             kwargs (Any): optional arguments
@@ -358,7 +368,6 @@ class Dataset(Table):
                 data_file,
                 qianfan_dataset_id,
                 qianfan_dataset_create_args,
-                huggingface_name,
                 is_download_to_local=False,
                 **kwargs,
             )

--- a/src/qianfan/dataset/dataset.py
+++ b/src/qianfan/dataset/dataset.py
@@ -167,6 +167,7 @@ class Dataset(Table):
                     list_of_json.append(json.dumps(entity, ensure_ascii=False))
             elif self.is_data_grouped():
                 log_info("enter grouped deserialization logic")
+                self._squash_group_number()
                 compo_list: List[List[Dict[str, Any]]] = []
                 for row in self.inner_table.to_pylist():
                     group_index = row[QianfanDataGroupColumnName]
@@ -653,6 +654,7 @@ class Dataset(Table):
         self,
         elem: Any,
         index: Any,
+        group_id: int = -1,
         add_new_group: bool = False,
         is_grouped: bool = True,
     ) -> Self:
@@ -662,9 +664,14 @@ class Dataset(Table):
         Args:
             elem (Union[List[Dict], Tuple[Dict], Dict]): Elements added to dataset
             index (int): where to insert element(s)
+            group_id (int):
+                which group id you want to apply to new element(s).
+                Default to -1, which means let group id be automatically
+                inferred from table.
             add_new_group (bool):
                 Whether elem has a new group id.
-                Only used when dataset is grouped.
+                Only used when dataset is grouped
+                and group_id is -1
             is_grouped (bool):
                 Are element in elem in same group.
                 Only used when dataset is grouped and elem is Sequence

--- a/src/qianfan/dataset/dataset.py
+++ b/src/qianfan/dataset/dataset.py
@@ -539,7 +539,12 @@ class Dataset(Table):
             log_warn("can't process qianfan dataset which isn't GenericText type")
             return ret_dict
 
-        operator_dict: Dict[str, List[Dict[str, Any]]] = {}
+        operator_dict: Dict[str, List[Dict[str, Any]]] = {
+            "clean": [],
+            "filter": [],
+            "deduplication": [],
+            "desensitization": [],
+        }
         for operator in operators:
             attr_dict = operator.model_dump()
             attr_dict.pop("operator_name")
@@ -548,9 +553,6 @@ class Dataset(Table):
             elem_dict = {"name": operator.operator_name, "args": attr_dict}
 
             operator_type = operator.operator_type
-            if operator_type not in operator_dict:
-                operator_dict[operator_type] = []
-
             operator_dict[operator_type].append(elem_dict)
 
         log_debug(f"operator args dict: {operator_dict}")

--- a/src/qianfan/dataset/dataset.py
+++ b/src/qianfan/dataset/dataset.py
@@ -359,6 +359,7 @@ class Dataset(Table):
                 qianfan_dataset_id,
                 qianfan_dataset_create_args,
                 huggingface_name,
+                is_download_to_local=False,
                 **kwargs,
             )
 

--- a/src/qianfan/dataset/process_interface.py
+++ b/src/qianfan/dataset/process_interface.py
@@ -63,9 +63,9 @@ class Processable(ABC):
         """
 
 
-class Appendable(ABC):
+class Addable(ABC):
     """
-    make object 'appendable'
+    make object 'addable'
     """
 
     @abstractmethod
@@ -77,7 +77,20 @@ class Appendable(ABC):
             elem (Any): element to append
 
         Returns:
-            Self: a new Appendable object after appending
+            Self: a new Addable object after appending
+        """
+
+    @abstractmethod
+    def insert(self, elem: Any, index: Any) -> Self:
+        """
+        insert an element to Appendable object
+
+        Args:
+            elem (Any): element(s) to insert
+            index (Any): where to insert element(s)
+
+        Returns:
+            Self: a new Addable object after inserting
         """
 
 

--- a/src/qianfan/dataset/schema.py
+++ b/src/qianfan/dataset/schema.py
@@ -26,7 +26,7 @@ from qianfan.utils import log_error, log_info
 def _data_format_converter(func: Callable) -> Callable:
     @functools.wraps(func)
     def inner(schema: Schema, table: Table, *args: Any, **kwargs: Any) -> bool:
-        if table.is_data_packed():
+        if table.is_dataset_packed():
             log_info("unpack dataset before validating")
             table.unpack()
             result = func(schema, table, *args, **kwargs)

--- a/src/qianfan/dataset/table.py
+++ b/src/qianfan/dataset/table.py
@@ -862,6 +862,9 @@ class Table(BaseModel, Addable, Listable, Processable):
         else:
             raise ValueError(f"Unsupported key type {type(key)}")
 
+    def __len__(self) -> int:
+        return self.row_number()
+
     def row_number(self) -> int:
         """
         get pyarrow table row count。

--- a/src/qianfan/dataset/table.py
+++ b/src/qianfan/dataset/table.py
@@ -455,16 +455,21 @@ class _PyarrowColumnManipulator(BaseModel, Addable, Listable, Processable):
         return self.table.drop_columns(index)
 
 
-class Table(BaseModel, Addable, Listable, Processable):
+class Table(Addable, Listable, Processable):
     """
     dataset representation on memory
     inherited from pyarrow.Table，implementing interface in process_interface.py
     """
 
-    class Config:
-        arbitrary_types_allowed = True
+    def __init__(self, inner_table: PyarrowTable) -> None:
+        """
+        Init a Table object
 
-    inner_table: PyarrowTable
+        Args:
+            inner_table (PyarrowTable): a pyarrow.Table object wrapped by Table
+        """
+        # 内部使用的 pyarrow.Table 对象
+        self.inner_table: PyarrowTable = inner_table
 
     def _row_op(self) -> _PyarrowRowManipulator:
         return _PyarrowRowManipulator(table=self.inner_table)

--- a/src/qianfan/dataset/utils.py
+++ b/src/qianfan/dataset/utils.py
@@ -11,15 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
-constants for dataset using
+utilities dataset needs
 """
 
-# 千帆数据集本地缓存文件夹的相对路径
-QianfanDatasetLocalCacheDir = ".qianfan_dataset_cache"
+from typing import Any, Dict, List, Sequence
 
-# 包装成单列表时使用的列名
-QianfanDatasetPackColumnName = "_pack"
+import pyarrow
 
-# 分组时应用的列名
-QianfanDataGroupColumnName = "_group"
+from qianfan.dataset.consts import QianfanDataGroupColumnName
+
+
+def _construct_table_from_nest_sequence(json_data_list: Sequence) -> pyarrow.Table:
+    inner_list: List[Dict[str, Any]] = []
+    for i in range(len(json_data_list)):
+        for pair in json_data_list[i]:
+            inner_list.append({**pair, QianfanDataGroupColumnName: i})
+    return pyarrow.Table.from_pylist(inner_list)

--- a/src/qianfan/tests/dataset/dataset_test.py
+++ b/src/qianfan/tests/dataset/dataset_test.py
@@ -24,6 +24,7 @@ from qianfan.dataset.data_operator import FilterCheckNumberWords
 from qianfan.dataset.data_source import DataSource, FormatType, QianfanDataSource
 from qianfan.dataset.dataset import Dataset
 from qianfan.dataset.schema import (
+    QianfanGenericText,
     QianfanNonSortedConversation,
     QianfanSortedConversation,
 )
@@ -112,6 +113,14 @@ def test_dataset_create():
         dataset_5.save(schema=QianfanNonSortedConversation())
     with pytest.raises(Exception):
         dataset_5.save(schema=QianfanSortedConversation())
+
+    fake_data_source_6 = FakeDataSource(
+        origin_data="this\nis\nmulti\nline\ndata", format=FormatType.Text
+    )
+    dataset_6 = Dataset.load(fake_data_source_6)
+    dataset_6.save(schema=QianfanGenericText())
+
+    assert fake_data_source_6.origin_data == fake_data_source_6.buffer
 
 
 def test_dataset_online_process():

--- a/src/qianfan/tests/dataset/dataset_test.py
+++ b/src/qianfan/tests/dataset/dataset_test.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
+from qianfan.dataset.consts import QianfanDataGroupColumnName
 from qianfan.dataset.data_operator import FilterCheckNumberWords
 from qianfan.dataset.data_source import DataSource, FormatType, QianfanDataSource
 from qianfan.dataset.dataset import Dataset
@@ -64,7 +65,7 @@ def test_dataset_create():
         ),
         format=FormatType.Jsonl,
     )
-    dataset = Dataset.load(fake_data_source)
+    dataset = Dataset.load(fake_data_source, organize_data_as_qianfan=False)
     list_ret = dataset.list()
     dataset.save(schema=QianfanNonSortedConversation())
     dataset.save(schema=QianfanSortedConversation())
@@ -131,3 +132,17 @@ def test_dataset_online_process():
     assert dataset.online_data_process(
         [FilterCheckNumberWords(number_words_min_cutoff=10)]
     )["is_succeeded"]
+
+
+def test_manipulator_group_add_and_delete():
+    dataset = Dataset.create_from_pyobj(
+        [{"test_column": "456"}, {"test_column": "123"}]
+    )
+    dataset.add_default_group_column()
+
+    assert QianfanDataGroupColumnName in dataset.col_names()
+    assert dataset.list()[1][QianfanDataGroupColumnName] == 1
+
+    dataset.delete_group_column()
+
+    assert QianfanDataGroupColumnName not in dataset.col_names()

--- a/src/qianfan/tests/dataset/dataset_test.py
+++ b/src/qianfan/tests/dataset/dataset_test.py
@@ -70,7 +70,7 @@ def test_dataset_create():
     dataset.save(schema=QianfanNonSortedConversation())
     dataset.save(schema=QianfanSortedConversation())
     assert fake_data_source.buffer == fake_data_source.fetch()
-    assert list(list_ret[0].keys())[0] == "prompt"
+    assert "prompt" in list_ret[0][0].keys()
 
     fake_data_source_2 = FakeDataSource(
         origin_data='{"prompt": "12", "response": [["12"]]}', format=FormatType.Json

--- a/src/qianfan/tests/dataset/table_test.py
+++ b/src/qianfan/tests/dataset/table_test.py
@@ -203,7 +203,10 @@ def test_insert_column():
     table.col_insert({"name": "test", "data": ["a", "b", "c", "d"]}, 0)
     table.col_insert({"name": "another_col", "data": [0, 0, 0, 0]}, 0)
 
+    col_names = table.col_names()
     assert table.column_number() == 3
+    assert col_names[0] == "another_col"
+    assert col_names[1] == "test"
 
 
 def test_list_column():

--- a/src/qianfan/tests/dataset/table_test.py
+++ b/src/qianfan/tests/dataset/table_test.py
@@ -422,3 +422,35 @@ def test_grouped_dataset_append():
     )
     assert table.list()[-1][QianfanDataGroupColumnName] == 5
     assert table.list()[-2][QianfanDataGroupColumnName] == 4
+
+
+def test_insert_group_data():
+    unpacked_inner_table = [
+        {"column1": "data1", "column2": "data2", QianfanDataGroupColumnName: 0},
+        {"column1": "data1", "column2": "data2", QianfanDataGroupColumnName: 0},
+        {"column1": "data1", "column2": "data2", QianfanDataGroupColumnName: 1},
+    ]
+
+    table = Table(inner_table=pyarrow.Table.from_pylist(unpacked_inner_table))
+
+    table.insert(
+        elem=[
+            {"column1": "data1", "column2": "data2"},
+            {"column1": "data1", "column2": "data2"},
+        ],
+        index=1,
+        group_id=12,
+        add_new_group=False,
+        is_grouped=False,
+    )
+
+    new_table_list = table.to_pylist()
+    assert new_table_list[1][QianfanDataGroupColumnName] == 12
+    assert new_table_list[2][QianfanDataGroupColumnName] == 13
+
+    table.pack()
+    table.unpack()
+
+    group_col = table.col_list(QianfanDataGroupColumnName)[QianfanDataGroupColumnName]
+
+    assert max(group_col) == 3

--- a/src/qianfan/tests/dataset/table_test.py
+++ b/src/qianfan/tests/dataset/table_test.py
@@ -47,6 +47,43 @@ def test_append_row():
     assert len(table.list()) == 5
 
 
+def test_insert_row():
+    table = Table(
+        inner_table=pyarrow.Table.from_pylist(
+            [{"name": "duck", "age": 3}, {"name": "monkey", "age": 24}]
+        )
+    )
+
+    with pytest.raises(ValueError):
+        table.append(["not a dict"])
+
+    with pytest.raises(ValueError):
+        table.append(123)
+
+    new_row = {"name": "tiger", "age": 5}
+
+    with pytest.raises(ValueError):
+        table.insert(new_row, -1)
+
+    with pytest.raises(ValueError):
+        table.insert(new_row, 3)
+
+    table.insert(new_row, 1)
+    assert len(table.list()) == 3
+
+    new_rows = [{"name": "pig", "age": 6}, {"name": "pig", "age": 6}]
+    table.insert(new_rows, 1)
+    assert len(table.list()) == 5
+
+    assert table.list() == [
+        {"name": "duck", "age": 3},
+        {"name": "pig", "age": 6},
+        {"name": "pig", "age": 6},
+        {"name": "tiger", "age": 5},
+        {"name": "monkey", "age": 24},
+    ]
+
+
 def test_list_row():
     table = Table(
         inner_table=pyarrow.Table.from_pydict({"a": [1, 2, 3], "b": ["a", "b", "c"]})
@@ -159,6 +196,14 @@ def test_append_column():
 
     with pytest.raises(ValueError):
         table.col_append({"name": "test", "data": ["a", "b", None, "d"]})
+
+
+def test_insert_column():
+    table = Table(inner_table=pyarrow.Table.from_pydict({"x": [1, 2, 3, 4]}))
+    table.col_insert({"name": "test", "data": ["a", "b", "c", "d"]}, 0)
+    table.col_insert({"name": "another_col", "data": [0, 0, 0, 0]}, 0)
+
+    assert table.column_number() == 3
 
 
 def test_list_column():

--- a/src/qianfan/tests/trainer_test.py
+++ b/src/qianfan/tests/trainer_test.py
@@ -38,7 +38,7 @@ def test_load_data_action():
     qianfan_data_source = QianfanDataSource.create_bare_dataset(
         "test", console_consts.DataTemplateType.NonSortedConversation
     )
-    ds = Dataset.load(source=qianfan_data_source, organize_data_as_qianfan=False)
+    ds = Dataset.load(source=qianfan_data_source, organize_data_as_group=True)
 
     res = LoadDataSetAction(ds).exec({"dataset_id": 123})
     assert isinstance(res, dict)
@@ -91,7 +91,7 @@ def test_trainer_sft_run():
     qianfan_data_source = QianfanDataSource.create_bare_dataset(
         "test", console_consts.DataTemplateType.NonSortedConversation
     )
-    ds = Dataset.load(source=qianfan_data_source, organize_data_as_qianfan=False)
+    ds = Dataset.load(source=qianfan_data_source, organize_data_as_group=True)
 
     eh = MyEventHandler()
     sft_task = LLMFinetune(
@@ -118,7 +118,7 @@ def test_trainer_sft_with_deploy():
     qianfan_data_source = QianfanDataSource.create_bare_dataset(
         "test", console_consts.DataTemplateType.NonSortedConversation
     )
-    ds = Dataset.load(source=qianfan_data_source, organize_data_as_qianfan=False)
+    ds = Dataset.load(source=qianfan_data_source, organize_data_as_group=True)
 
     eh = MyEventHandler()
     sft_task = LLMFinetune(

--- a/src/qianfan/tests/trainer_test.py
+++ b/src/qianfan/tests/trainer_test.py
@@ -38,7 +38,7 @@ def test_load_data_action():
     qianfan_data_source = QianfanDataSource.create_bare_dataset(
         "test", console_consts.DataTemplateType.NonSortedConversation
     )
-    ds = Dataset.load(source=qianfan_data_source)
+    ds = Dataset.load(source=qianfan_data_source, organize_data_as_qianfan=False)
 
     res = LoadDataSetAction(ds).exec({"dataset_id": 123})
     assert isinstance(res, dict)
@@ -91,7 +91,7 @@ def test_trainer_sft_run():
     qianfan_data_source = QianfanDataSource.create_bare_dataset(
         "test", console_consts.DataTemplateType.NonSortedConversation
     )
-    ds = Dataset.load(source=qianfan_data_source)
+    ds = Dataset.load(source=qianfan_data_source, organize_data_as_qianfan=False)
 
     eh = MyEventHandler()
     sft_task = LLMFinetune(
@@ -118,7 +118,7 @@ def test_trainer_sft_with_deploy():
     qianfan_data_source = QianfanDataSource.create_bare_dataset(
         "test", console_consts.DataTemplateType.NonSortedConversation
     )
-    ds = Dataset.load(source=qianfan_data_source)
+    ds = Dataset.load(source=qianfan_data_source, organize_data_as_qianfan=False)
 
     eh = MyEventHandler()
     sft_task = LLMFinetune(


### PR DESCRIPTION
<!-- Thank you for contributing to qianfan!

Replace this entire comment with:
  - **Description:** add two different dataset format support

Please make sure your PR is passing linting and testing before submitting. Run `make format`, `make lint` and `make test` to check this locally.

 -->

- 新功能：
  - Dataset 同时支持数组模式表示与 Table 模式表示
  - 新增 Insert 函数
  - 支持用户额外传递私有 BOS 配置，中转上传数据集到公共 BOS 数据集中
  - 支持直接从 BOS 文件创建并导入数据集
  - 自动 Group ID 压缩与重排
  - Schema 校验失败时，现提供官方格式示例地址
  - 可以使用 `len()` 方法获取 Dataset 内数据的数量
- Bug Fix:
  - 修复了当目的文件路径不存在时导出失败的问题
  - 修复了 `col_append` 可添加相同列名新列的问题
  - 从 Table 与 Dataset 中移除了 `pydantic.BaseModel`
  - 增加了更多单测
- 其它:
  - 优化 `requestor` 的错误信息

关联 Issue:
#91 #97 #98 #100 #101
