### PR TITLE
fix: client not showing message when only one response

### DIFF
--- a/src/qianfan/common/client/chat.py
+++ b/src/qianfan/common/client/chat.py
@@ -100,9 +100,8 @@ class ChatClient(object):
                 response = self.client.do(messages=messages, stream=True)
                 s = ""
                 for resp in response:
-                    if not resp["is_end"]:
-                        s += resp["result"]
-                        live.update(Markdown(s), refresh=True)
+                    s += resp["result"]
+                    live.update(Markdown(s), refresh=True)
             messages.append(s, role=QfRole.Assistant)
             rprint()
 


### PR DESCRIPTION
  - **Description:** 修复流式返回只有一条消息时，client不显示结果
  - **Issue:** /
  - **Dependencies:** /
  - **Tag maintainer:** @stonekim, @danielhjz, @ZingLix @Dobiichi-Origami.
