### PR TITLE
optimize: support rendering prompt with non-str

### DIFF
--- a/src/qianfan/common/prompt/prompt.py
+++ b/src/qianfan/common/prompt/prompt.py
@@ -288,7 +288,7 @@ class Prompt(HubSerializable):
         for v in self.variables:
             if v not in kwargs:
                 raise InvalidArgumentError(f"variable `{v}` is not provided")
-            prompt = prompt.replace(f"{left_id}{v}{right_id}", kwargs[v])
+            prompt = prompt.replace(f"{left_id}{v}{right_id}", str(kwargs[v]))
         neg_prompt = None
         if (
             self.scene_type == PromptSceneType.Text2Image

--- a/src/qianfan/tests/prompt_class_test.py
+++ b/src/qianfan/tests/prompt_class_test.py
@@ -166,6 +166,10 @@ def test_render():
     assert p.variables == ["v2", "v3"]
     assert p.render(v1="a", v2="3", v3="4") == ("{v1}3x 4", None)
 
+    p = Prompt(template="{v1} {v2}")
+    assert p.variables == ["v1", "v2"]
+    assert p.render(v1=1, v2={}) == ("1 {}", None)
+
 
 def test_delete():
     """


### PR DESCRIPTION
  - **Description:** Prompt 渲染允许传递非字符串
  - **Issue:** #217 
  - **Dependencies:** /
  - **Tag maintainer:**  @stonekim, @danielhjz, @Dobiichi-Origami.


