### PR TITLE
修复高版本 NodeJs 开启 stream 后请求失败的问题

### DIFF
--- a/javascript/src/HttpClient/index.ts
+++ b/javascript/src/HttpClient/index.ts
@@ -102,6 +102,12 @@ class HttpClient extends EventEmitter {
     public async establishSSEConnection(options: AxiosRequestConfig): Promise<AsyncIterable<any>> {
         const {url, headers, data} = options;
         try {
+            /**
+             * NodeJS V18 原生的 fetch 定义 Connection header 会报错
+             * @see https://github.com/nodejs/undici/blob/1f2cca68f0608e31eb02f0d08956786dd1260ef9/lib/core/request.js
+             * @see https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
+             */
+            delete headers.Connection;
             const sseStream: AsyncIterable<any> = Stream.fromSSEResponse(
                 await fetch(url, {
                     method: 'POST',


### PR DESCRIPTION
NodeJs V18.19.0 启用 stream 后请求失败，只出现 `fetch failed` 错误
<img width="623" alt="image" src="https://github.com/baidubce/bce-qianfan-sdk/assets/1033317/d9e7ce45-182a-4dae-bc5e-20d16dd6302e">

NodeJS 的 undici 会对 headers 进行校验, 如下图:
<img width="685" alt="image" src="https://github.com/baidubce/bce-qianfan-sdk/assets/1033317/423fe1f4-732c-497a-9058-98545ffa20e1">

因不确定 `Connection` 在非 `stream` 类型的请求时对千帆服务的影响，暂时只在使用 NodeJs Fetch 的时候删除受影响的请求头。

相关资料:
- [nodejs/undici](https://github.com/nodejs/undici/blob/1f2cca68f0608e31eb02f0d08956786dd1260ef9/lib/core/request.js#L285)
- [Forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name)
