### PR TITLE
fix: disable default auto truncate overlong messages

### DIFF
--- a/cookbook/auto_truncate_msg.ipynb
+++ b/cookbook/auto_truncate_msg.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SDK 自动遗忘过长的对话历史\n",
+    "\n",
+    "模型对于输入的对话 token 长度有限制，当长度过长时会报错，为解决该问题，SDK 支持自动遗忘过长的对话历史，仅保留最近的对话历史。\n",
+    "\n",
+    "注意：需要 SDK 版本 >= 0.3.3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qianfan\n",
+    "\n",
+    "messages = [\n",
+    "    {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": \"你好\" * 10000, # 设置了特别长的回复\n",
+    "    },\n",
+    "    {\n",
+    "        \"role\": \"assistant\",\n",
+    "        \"content\": \"你好\",\n",
+    "    },\n",
+    "    {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": \"介绍一下文心一言\",\n",
+    "    }\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "只需要在调用模型时，传入 `truncate_overlong_msgs=True`，SDK 就会自动遗忘过长的的消息。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[INFO] [03-06 19:15:34] chat_completion.py:979 [t:139750384353536]: Top 2 messages are truncated due to max_input_chars limit\n",
+      "[INFO] [03-06 19:15:34] openapi_requestor.py:316 [t:139750384353536]: requesting llm api endpoint: /chat/completions\n"
+     ]
+    }
+   ],
+   "source": [
+    "resp = qianfan.ChatCompletion(model=\"ERNIE-Bot\").do(messages, truncate_overlong_msgs=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "从日志中可以看到，最早的两条消息被截断了，其中第一条是过长的消息，第二条则由于其为模型的回复，不能作为第一条消息而被截断。同时，我们也可以从调试信息中确定所发送的内容。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'role': 'user', 'content': '介绍一下文心一言'}]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp.request.json_body['messages']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "还可以通过 `get_model_info` 方法获取模型所支持的最大长度。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20000"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qianfan.ChatCompletion.get_model_info(\"ERNIE-Bot\").max_input_chars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7168"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qianfan.ChatCompletion.get_model_info(\"ERNIE-Speed\").max_input_tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "py311",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/qianfan/resources/llm/chat_completion.py
+++ b/python/qianfan/resources/llm/chat_completion.py
@@ -478,7 +478,7 @@ class ChatCompletion(BaseResource):
         backoff_factor: float = DefaultValue.RetryBackoffFactor,
         auto_concat_truncate: bool = False,
         truncated_continue_prompt: str = DefaultValue.TruncatedContinuePrompt,
-        truncate_overlong_msgs: bool = True,
+        truncate_overlong_msgs: bool = False,
         **kwargs: Any,
     ) -> Union[QfResponse, Iterator[QfResponse]]:
         """
@@ -693,7 +693,7 @@ class ChatCompletion(BaseResource):
         backoff_factor: float = DefaultValue.RetryBackoffFactor,
         auto_concat_truncate: bool = False,
         truncated_continue_prompt: str = DefaultValue.TruncatedContinuePrompt,
-        truncate_overlong_msgs: bool = True,
+        truncate_overlong_msgs: bool = False,
         **kwargs: Any,
     ) -> Union[QfResponse, AsyncIterator[QfResponse]]:
         """

--- a/python/qianfan/tests/chat_completion_test.py
+++ b/python/qianfan/tests/chat_completion_test.py
@@ -651,7 +651,7 @@ def test_keyword_arguments_passing():
 
 def test_truncated_message():
     messages = [{"role": "user", "content": "hello " * 10000}]
-    resp = qianfan.ChatCompletion().do(messages=messages)
+    resp = qianfan.ChatCompletion().do(messages=messages, truncate_overlong_msgs=True)
     req = resp["_request"]
     req_messages = req["messages"]
     assert len(req_messages) == 1
@@ -659,7 +659,7 @@ def test_truncated_message():
     messages.extend(
         [{"role": "assistant", "content": "hi1"}, {"role": "user", "content": "hi2"}]
     )
-    resp = qianfan.ChatCompletion().do(messages=messages)
+    resp = qianfan.ChatCompletion().do(messages=messages, truncate_overlong_msgs=True)
     req_messages = resp["_request"]["messages"]
     assert len(req_messages) == 1
     assert req_messages[0]["content"] == "hi2"
@@ -672,7 +672,9 @@ def test_truncated_message():
         # cut here
         {"role": "user", "content": "s5"},
     ]
-    resp = qianfan.ChatCompletion(model="BLOOMZ-7B").do(messages=messages)
+    resp = qianfan.ChatCompletion(model="BLOOMZ-7B").do(
+        messages=messages, truncate_overlong_msgs=True
+    )
     req_messages = resp["_request"]["messages"]
     assert len(req_messages) == 1
     assert req_messages[0]["content"] == "s5"
@@ -685,7 +687,9 @@ def test_truncated_message():
         {"role": "assistant", "content": "s4"},
         {"role": "user", "content": "s5"},
     ]
-    resp = qianfan.ChatCompletion(model="BLOOMZ-7B").do(messages=messages)
+    resp = qianfan.ChatCompletion(model="BLOOMZ-7B").do(
+        messages=messages, truncate_overlong_msgs=True
+    )
     req_messages = resp["_request"]["messages"]
     assert len(req_messages) == 3
     assert req_messages[0]["content"] == "s3"
@@ -701,7 +705,9 @@ def test_truncated_message():
         {"role": "assistant", "content": "s4"},
         {"role": "user", "content": "s5"},
     ]
-    resp = qianfan.ChatCompletion(model="ERNIE-Bot-8k").do(messages=messages)
+    resp = qianfan.ChatCompletion(model="ERNIE-Bot-8k").do(
+        messages=messages, truncate_overlong_msgs=True
+    )
     req_messages = resp["_request"]["messages"]
     assert len(req_messages) == 3
     assert req_messages[0]["content"] == "h " * 3000
@@ -725,7 +731,9 @@ def test_truncated_message():
         {"role": "assistant", "content": "s4"},
         {"role": "user", "content": "s5"},
     ]
-    resp = qianfan.ChatCompletion(model="ERNIE-Bot").do(messages=messages)
+    resp = qianfan.ChatCompletion(model="ERNIE-Bot").do(
+        messages=messages, truncate_overlong_msgs=True
+    )
     req_messages = resp["_request"]["messages"]
     assert len(req_messages) == 3
     assert req_messages[0]["content"] == "s3"


### PR DESCRIPTION
  - **Description:** 默认不启用自动截断过长消息，并增加cookbook
  - **Issue:** #303 
  - **Dependencies:** /
  - **Tag maintainer:**  @stonekim, @danielhjz, @Dobiichi-Origami.

