### PR TITLE
fix: prompt optimize not working when identifier is not {}

### DIFF
--- a/python/qianfan/autotuner/runner/qianfan_runner.py
+++ b/python/qianfan/autotuner/runner/qianfan_runner.py
@@ -83,7 +83,7 @@ class QianfanRunner(InferRunner):
         if self.prompt is not None:
             for i in range(len(input_list)):
                 content = input_list[i][-1]["content"]
-                new_content = self.prompt.render(content=content)
+                new_content, _ = self.prompt.render(content=content)
                 input_list[i][-1]["content"] = new_content
         return input_list
 

--- a/python/qianfan/common/prompt/prompt.py
+++ b/python/qianfan/common/prompt/prompt.py
@@ -543,7 +543,7 @@ class Prompt(HubSerializable):
             time.sleep(1)
         optimized_prompt = resp["result"]["optimizeContent"]
 
-        return Prompt(optimized_prompt)
+        return Prompt(optimized_prompt, identifier=self.identifier)
 
     @dataclass
     class PromptEvaluateResult(object):


### PR DESCRIPTION
  - **Description:** identifier 不是 {} 时优化会报错
  - **Issue:** #417 
  - **Dependencies:** /
  - **Tag maintainer:**  @stonekim, @danielhjz, @Dobiichi-Origami.

