### PR TITLE
fix: python ci workflow not working on macos

### DIFF
--- a/.github/workflows/py_ci.yml
+++ b/.github/workflows/py_ci.yml
@@ -33,6 +33,14 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+        exclude:
+          - { python-version: "3.7", os: "macos-latest" }
+          - { python-version: "3.8", os: "macos-latest" }
+          - { python-version: "3.9", os: "macos-latest" }
+        include:
+          - { python-version: "3.7", os: "macos-13" }
+          - { python-version: "3.8", os: "macos-13" }
+          - { python-version: "3.9", os: "macos-13" }
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
  - **Description:** macos-latest 指向 macos14，用的是 m1，不支持3.9以前的版本
  - **Issue:** /
  - **Dependencies:** /
  - **Tag maintainer:** @stonekim, @danielhjz, @Dobiichi-Origami.

