### PR TITLE
fix: system is ignored when truncating overlong msgs

### DIFF
--- a/python/qianfan/resources/llm/chat_completion.py
+++ b/python/qianfan/resources/llm/chat_completion.py
@@ -1473,6 +1473,8 @@ class ChatCompletion(BaseResource):
 
         if model_info.max_input_chars is not None:
             chars_limit = model_info.max_input_chars
+            if "system" in body:
+                chars_limit -= len(body["system"])
             msg_list = body["messages"]
             last_msg = msg_list[-1]
             cur_length = len(last_msg["content"]) if last_msg.get("content") else 0
@@ -1494,6 +1496,8 @@ class ChatCompletion(BaseResource):
 
         if model_info.max_input_tokens is not None:
             token_limit = model_info.max_input_tokens
+            if "system" in body:
+                token_limit -= Tokenizer.count_tokens(body["system"], mode="local")
             msg_list = body["messages"]
             last_msg = msg_list[-1]
             cur_length = (

--- a/python/qianfan/tests/chat_completion_test.py
+++ b/python/qianfan/tests/chat_completion_test.py
@@ -740,6 +740,47 @@ def test_truncated_message():
     assert req_messages[0]["content"] == "s3"
     assert req_messages[2]["content"] == "s5"
 
+    # test msgs with system
+    messages = [
+        {"role": "user", "content": "s "},
+        {"role": "assistant", "content": "s2"},
+        {"role": "user", "content": "h " * 3000},
+        {"role": "assistant", "content": "s4"},
+        {"role": "user", "content": "s5"},
+    ]
+    system = "s " * 3000
+    resp = qianfan.ChatCompletion(model="ERNIE-Bot-8k").do(
+        messages=messages, truncate_overlong_msgs=True
+    )
+    req_messages = resp["_request"]["messages"]
+    assert len(req_messages) == 5
+
+    resp = qianfan.ChatCompletion(model="ERNIE-Bot-8k").do(
+        messages=messages, truncate_overlong_msgs=True, system=system
+    )
+    req_messages = resp["_request"]["messages"]
+    assert len(req_messages) == 1
+    assert req_messages[0]["content"] == "s5"
+
+    messages = [
+        {"role": "user", "content": "s "},
+        {"role": "assistant", "content": "s2"},
+        {"role": "user", "content": "h " * 3000},
+        {"role": "assistant", "content": "s4"},
+        {"role": "user", "content": "s " * 10000},
+    ]
+    resp = qianfan.ChatCompletion(model="ERNIE-Bot-8k").do(
+        messages=messages, truncate_overlong_msgs=True, system=system
+    )
+    req_messages = resp["_request"]["messages"]
+    assert len(req_messages) == 1
+
+    resp = qianfan.ChatCompletion(model="ERNIE-Bot-8k").do(
+        messages=messages[-1:], truncate_overlong_msgs=True, system=system
+    )
+    req_messages = resp["_request"]["messages"]
+    assert len(req_messages) == 1
+
 
 def test_auto_model_list():
     model_list = qianfan.ChatCompletion._supported_models()


### PR DESCRIPTION
  - **Description:** 修复截取过长消息时未考虑 system 字段的问题
  - **Issue:** #514 
  - **Dependencies:** /
  - **Tag maintainer:** @stonekim, @danielhjz, @ZingLix @Dobiichi-Origami.

