### PR TITLE
doc: 补充获取 Bearer token 的示例中 IAM 对象的导入路径

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -190,6 +190,8 @@ os.environ['QIANFAN_BEARER_TOKEN'] = 'your_bearer_token'
 
 ```python
 import os
+from qianfan.resources import IAM
+
 os.environ['QIANFAN_ACCESS_KEY'] = 'your_access_key'
 os.environ['QIANFAN_SECRET_KEY'] = 'your_secret_key'
 


### PR DESCRIPTION
Replace this entire comment with:
  - **Description:** 补充了文档示例中获取 Bearer token 的示例中 IAM 对象的导入路径
  - **Tag maintainer:** @stonekim 

文档中没有提到示例中的 IAM 对象导入路径，用起来得翻找代码，给他补上一行方复制示例代码出来直接用。