### PR TITLE
Fix:千帆go sdk 流式工具调用返回结构体问题修复;

### DIFF
--- a/go/qianfan/chat_completion_v2.go
+++ b/go/qianfan/chat_completion_v2.go
@@ -74,8 +74,8 @@ type ChatCompletionV2Message struct {
 }
 
 type ChatCompletionV2Delta struct {
-	Content   string     `mapstructure:"content"`              // 生成结果
-	ToolCalls []ToolCall `mapstructure:"tool_calls,omitempty"` // 函数调用
+	Content   string     `mapstructure:"content"`                                          // 生成结果
+	ToolCalls []ToolCall `mapstructure:"tool_calls,omitempty" json:"tool_calls,omitempty"` // 函数调用
 }
 
 type StreamOptions struct {
@@ -104,6 +104,7 @@ type ResponseFormat struct {
 }
 
 type ToolCall struct {
+	Index    int            `mapstructure:"index" json:"index,omitempty"`
 	Id       string         `mapstructure:"id" json:"id,omitempty"`
 	ToolType string         `mapstructure:"type" json:"type,omitempty"`
 	Function FunctionCallV2 `mapstructure:"function" json:"function,omitempty"`


### PR DESCRIPTION
**Description:**
- 修复了 v2 版本在调用 deepseek-v3 时，工具规划输出解析结构缺少 tag 定义和 index 字段的问题。
- 为 `ChatCompletionV2Delta` 结构体的 `ToolCalls` 字段补充了 `json:"tool_calls,omitempty"` tag，保证序列化/反序列化时字段正确映射。
![image](https://github.com/user-attachments/assets/fa81635c-fb08-411a-9ab8-b743de1d424b)

**Dependencies:**
- 无新增依赖。

@stonekim 请帮忙 review 一下这个 PR，谢谢！